### PR TITLE
Updated New-EncryptedVM.ps1 script

### DIFF
--- a/keyvault-diskencryption-lab/New-EncryptedVM.ps1
+++ b/keyvault-diskencryption-lab/New-EncryptedVM.ps1
@@ -1,13 +1,16 @@
 # Author: Christopher Jackson, Logan Rakai
 # New-EncryptedVM.ps1
 #
-# This PowerShell script creates a new Resource Group where it deploys a new Windows VM, a Keyvault with an AD App and KeyEncryptionKey which is uses to encrypt the VM
+# This PowerShell script deploys a new Windows VM and a KeyVault with a KeyEncryptionKey which is uses to encrypt the VM
 # Please login to your Azure Environment before running this script.  This script create all new resources
 # For more info: https://docs.microsoft.com/en-us/azure/security/azure-security-disk-encryption  
 
-Add-AzAccount -SubscriptionId "b197ebe7-8059-4dbe-90a8-15f7bf3d746f" 
+#region Azure Login
+Connect-AzAccount 
+#endregion 
 
-$ResourceGroupName = "cal-930-16"
+#region Variables
+$ResourceGroupName = "REPLACE_ME"
 $VMName = "EncryptWin1"
 $Location = "South Central US"
 $Subnet1Name = "default"
@@ -25,60 +28,9 @@ $OSPublisherName = "MicrosoftWindowsServer"
 $OSOffer = "WindowsServer"
 $OSSKu = "2019-Datacenter"
 $OSVersion = "latest"
-
-
-# Create the Resource Group
-#Write-Host "Creating ResourceGroup: $ResourceGroupName..."
-#New-AzResourceGroup -Name $ResourceGroupName -Location $Location
-
-#region KeyVault
-############################## Create and Deploy the KeyVault and Keys ###############################
-$keyVaultName = $("MyKeyVault1" + "-" + $ResourceGroupName)
-$aadAppName = $("MyApp1" + "-" + $ResourceGroupName)
-$aadClientID = ""
-$aadClientSecret = ""
-$keyEncryptionKeyName = $("MyKey1" + "-" + $ResourceGroupName)
-
-# Create a new AD application
-Write-Host "Creating a new AD Application: $aadAppName..."
-$now = [System.DateTime]::Now
-$oneYearFromNow = $now.AddYears(1)
-$ADApp =  New-AzADApplication -DisplayName $aadAppName -StartDate $now -EndDate $oneYearFromNow
-$credential = New-Object -TypeName "Microsoft.Azure.PowerShell.Cmdlets.Resources.MSGraph.Models.ApiV10.MicrosoftGraphPasswordCredential" -Property @{'DisplayName' = 'labPassword';}
-$appCredential = New-AzADAppCredential -ObjectId $ADapp.Id
-$aadClientSecret = $appCredential.SecretText
-$servicePrincipal = New-AzADServicePrincipal -ApplicationId $ADApp.AppId
-$aadClientID = $servicePrincipal.AppId
-Write-Host "Successfully created a new AAD Application: $aadAppName with ID: $aadClientID"
-
-
-# Create the KeyVault
-Write-Host "Creating the KeyVault: $keyVaultName..."
-$keyVault = New-AzKeyVault -VaultName $keyVaultName -ResourceGroupName $ResourceGroupName -Sku Standard -Location $Location -EnabledForDiskEncryption;
-# Set the permissions required to enable the DiskEncryption Policy
-Set-AzKeyVaultAccessPolicy -VaultName $keyVaultName -ServicePrincipalName $aadClientID `
-   -PermissionsToKeys get,list,encrypt,decrypt,create,import,sign,verify,wrapKey,unwrapKey `
-   -PermissionsToSecrets get,list,set
-Set-AzKeyVaultAccessPolicy -VaultName $keyVaultName -EnabledForDiskEncryption
-$diskEncryptionKeyVaultUrl = $keyVault.VaultUri
-$keyVaultResourceId = $keyVault.ResourceId
-
-# Create the KeyEncryptionKey (KEK)
-Write-Host "Creating the KeyEncryptionKey (KEK): $keyEncryptionKeyName..."
-$kek = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $keyEncryptionKeyName -Destination Software
-$keyEncryptionKeyUrl = $kek.Key.Kid
-
-# Output the values of the KeyVault
-Write-Host "KeyVault values that will be needed to enable encryption on the VM" -foregroundcolor Cyan
-Write-Host "KeyVault Name: $keyVaultName" -foregroundcolor Cyan
-Write-Host "aadClientID: $aadClientID" -foregroundcolor Cyan
-Write-Host "aadClientSecret: $aadClientSecret" -foregroundcolor Cyan
-Write-Host "diskEncryptionKeyVaultUrl: $diskEncryptionKeyVaultUrl" -foregroundcolor Cyan
-Write-Host "keyVaultResourceId: $keyVaultResourceId" -foregroundcolor Cyan
-Write-Host "keyEncryptionKeyURL: $keyEncryptionKeyUrl" -foregroundcolor Cyan
 #endregion 
 
- #region VM
+#region VM
 ############################## Create and Deploy the VM ###############################
 # Create storage account
 Write-Host "Creating storage account: $StorageName..."
@@ -116,12 +68,37 @@ Write-Host "Building the VM: $VMName..."
 New-AzVM -ResourceGroupName $ResourceGroupName -Location $Location -VM $VirtualMachine
 #endregion 
 
+#region KeyVault
+############################## Create and Deploy the KeyVault and Keys ###############################
+$keyVaultName = $("MyKeyVault1" + "-" + $ResourceGroupName)
+$keyEncryptionKeyName = $("MyKey1" + "-" + $ResourceGroupName)
+
+# Create the KeyVault
+Write-Host "Creating the KeyVault: $keyVaultName..."
+$keyVault = New-AzKeyVault -VaultName $keyVaultName -ResourceGroupName $ResourceGroupName -Sku Standard -Location $Location -EnabledForDiskEncryption;
+# Set the permissions required to enable the DiskEncryption Policy
+Set-AzKeyVaultAccessPolicy -VaultName $keyVaultName -EnabledForDiskEncryption
+$diskEncryptionKeyVaultUrl = $keyVault.VaultUri
+$keyVaultResourceId = $keyVault.ResourceId
+
+# Create the KeyEncryptionKey (KEK)
+Write-Host "Creating the KeyEncryptionKey (KEK): $keyEncryptionKeyName..."
+$kek = Add-AzKeyVaultKey -VaultName $keyVaultName -Name $keyEncryptionKeyName -Destination Software
+$keyEncryptionKeyUrl = $kek.Key.Kid
+
+# Output the values of the KeyVault
+Write-Host "KeyVault values that will be needed to enable encryption on the VM" -foregroundcolor Cyan
+Write-Host "KeyVault Name: $keyVaultName" -foregroundcolor Cyan
+Write-Host "diskEncryptionKeyVaultUrl: $diskEncryptionKeyVaultUrl" -foregroundcolor Cyan
+Write-Host "keyVaultResourceId: $keyVaultResourceId" -foregroundcolor Cyan
+Write-Host "keyEncryptionKeyURL: $keyEncryptionKeyUrl" -foregroundcolor Cyan
+#endregion 
+
 #region Encryption Extension
 ############################## Deploy the VM Encryption Extension ###############################
 # Build the encryption extension
 Write-Host "Deploying the VM Encryption Extension..."
 Set-AzVMDiskEncryptionExtension -ResourceGroupName $resourceGroupName -VMName $vmName `
--AadClientID $aadClientID -AadClientSecret $aadClientSecret `
 -DiskEncryptionKeyVaultUrl $diskEncryptionKeyVaultUrl -DiskEncryptionKeyVaultId $keyVaultResourceId `
 -VolumeType "OS" `
 -KeyEncryptionKeyUrl $keyEncryptionKeyUrl `


### PR DESCRIPTION
Using `Connect-AzAccount` removes the step of updating subscription ID

The Microsoft Entra application parameter requirement to enable VM disk encryption has been removed with the new release:
https://learn.microsoft.com/en-us/azure/virtual-machines/windows/disk-encryption-key-vault-aad

The Azure AD Powershell module will be deprecated March 30, 2024